### PR TITLE
Fix get_favorite_for typo in templatetags

### DIFF
--- a/favit/templatetags/favit_tags.py
+++ b/favit/templatetags/favit_tags.py
@@ -67,7 +67,7 @@ def get_favorite_for(obj, user):
     {% endwith %}
     """
 
-    return Favorites.objects.get_favorite(user, obj)
+    return Favorite.objects.get_favorite(user, obj)
 
 
 @register.filter


### PR DESCRIPTION
This was preventing the tag to work
